### PR TITLE
Take nixpkgs.lib functions in poetryOverrides.nix from flake nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     ...
   } @ inputs: let
     no_system_outputs = {
-      poetryOverrides = import ./poetryOverrides.nix;
+      lib.poetryOverrides = import ./poetryOverrides.nix {inherit nixpkgs;};
     };
 
     all_system_outputs = flake-utils.lib.eachDefaultSystem (system: let

--- a/pkgs/python_ot/default.nix
+++ b/pkgs/python_ot/default.nix
@@ -8,7 +8,7 @@
   ...
 }: let
   poetry2nix = inputs.poetry2nix.lib.mkPoetry2Nix {inherit pkgs;};
-  poetryOverrides = inputs.self.poetryOverrides {inherit pkgs;};
+  poetryOverrides = inputs.self.lib.poetryOverrides;
 in
   poetry2nix.mkPoetryEnv {
     projectDir = ./.;

--- a/poetryOverrides.nix
+++ b/poetryOverrides.nix
@@ -1,7 +1,7 @@
 # Copyright lowRISC Contributors.
 # Licensed under the MIT License, see LICENSE for details.
 # SPDX-License-Identifier: MIT
-{pkgs, ...}: let
+{nixpkgs, ...}: let
   # https://github.com/nix-community/poetry2nix/blob/master/docs/edgecases.md
   # poetry2nix tries to build the python packages based on the information
   # given in their own build description files (setup.py etc.)
@@ -61,7 +61,7 @@
     };
   };
 in
-  pkgs.lib.composeManyExtensions [
+  nixpkgs.lib.composeManyExtensions [
     preferwheel-overlay
     buildreqs-overlay
     dontwrap-overlay


### PR DESCRIPTION
It seems cleaner to me to just use the local flake input when we are just pulling functions from lib. The consumer shouldn't need to provide it's local packageset just for access to lib.

API change, so requires a change in downstream flakes consuming this.
I also change the attribute to be available at `lib.poetryOverrides`, which removes the following warning from `nix flake check`:
```
warning: unknown flake output 'poetryOverrides'
```