### PR TITLE
Add fixed xmake derivation

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,7 @@
   bazel_ot = pkgs.callPackage ./bazel_ot {};
   llvm_cheriot = pkgs.callPackage ./llvm_cheriot.nix {};
   ibex-cosim = pkgs.callPackage ./ibex-cosim.nix {};
+  xmake = import ./xmake.nix {inherit pkgs;};
 }
 // pkgs.lib.optionalAttrs (pkgs.system == "x86_64-linux") {
   lowrisc-toolchain-gcc-rv32imcb = pkgs.callPackage ./lowrisc-toolchain-gcc-rv32imcb.nix {};

--- a/pkgs/xmake.nix
+++ b/pkgs/xmake.nix
@@ -1,0 +1,10 @@
+# Copyright lowRISC Contributors.
+# SPDX-License-Identifier: MIT
+{pkgs}:
+pkgs.xmake.overrideAttrs (prev: {
+  # Remove the cjson lua package from the dependancies.
+  buildInputs = builtins.filter (input: input != pkgs.lua.pkgs.cjson) prev.buildInputs;
+  # Reset the configure flags so they don't contain `external=y`.
+  configureFlags = [];
+  enableParallelBuilding = true;
+})


### PR DESCRIPTION
The xmake derivation in nixpkgs uses `lua.pkgs.cjson`, but xmake has it's own patched version of `cjson` with hex literals support. The CHERIoT RTOS requires hex literals to build.

This derivation uses the internal patched version `cjson`.

Note, there is a second fallback json parser within in xmake which doesn't have hex literal support either.

We are planning to upstream this fix and remove our version of the package once we have.