### PR TITLE
Use pname instead of derviation comparision when filtering

### DIFF
--- a/pkgs/xmake.nix
+++ b/pkgs/xmake.nix
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 {pkgs}:
 pkgs.xmake.overrideAttrs (prev: {
-  # Remove the cjson lua package from the dependancies.
-  buildInputs = builtins.filter (input: !(builtins.elem input [pkgs.lua.pkgs.cjson pkgs.tbox])) prev.buildInputs;
   # Reset the configure flags so they don't contain `external=y`.
+  # This will cause vendored packages to be used instead of external (Nix-built packages).
+  # We need this because lua-cjson is different from xmake's vendored cjson when it comes to hex literals.
   configureFlags = [];
+  # Remove vendored packages from the dependencies.
+  buildInputs = builtins.filter (input: !(builtins.elem input.pname ["lua-cjson" "tbox" "xmake-core-sv"])) prev.buildInputs;
   enableParallelBuilding = true;
 })


### PR DESCRIPTION
This allows xmake package to be evaluated on MacOS where its dependency evaluation will fail due to unsupported system.