### PR TITLE
Add opentitan python environment to edaExtraDeps for otbnsim

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -15,8 +15,8 @@
   extraPkgs ? [],
   ...
 }: let
-  # These dependencies are required for building user DPI C/C++ code.
-  edaExtraDeps = with pkgs; [elfutils openssl];
+  # These dependencies are required for building user DPI C/C++ code, and cosimulation models.
+  edaExtraDeps = with pkgs; [elfutils openssl python_ot];
 
   # Bazel rules_rust expects build PIE binary in opt build but doesn't request PIE/PIC, so force PIC
   gcc-patched = wrapCCWith {
@@ -44,10 +44,17 @@ in
           # For serde-annotate which can be built with just cargo
           rustup
 
+          # For the OTBN simulator
+          ninja
+
+          # dvsim uses git for logging/tagging purposes
+          git
+
           # Bazel downloads Rust compilers which are not patchelfed and they need this.
           zlib
           openssl
           curl
+          util-linux # flock for bazelisk
 
           gcc-patched
           pkg-config-patched


### PR DESCRIPTION
OTBN block level DV uses a python ISS, which is built and invoked via DPI code for cosimulation using an RTL simulator.

Our current wrappers use 'execl' to launch the python interpreter, and then communicate with the ISS via stdstreams. To allow the EDA tools to see the python interpreter and package set, we need to pass it into their FHSenv wrappers using the 'edaExtraDeps' argument.

```
# hw/ip/otbn/dv/model/iss_wrapper.cc:318
execl("/usr/bin/env", "/usr/bin/env", "python3", "-u", model_path.c_str(),  NULL);
```