### PR TITLE
Force usage of Apple SDK 11 for xmake

### DIFF
--- a/pkgs/xmake/default.nix
+++ b/pkgs/xmake/default.nix
@@ -10,40 +10,45 @@
   ncurses,
   lz4,
   darwin,
-}:
-stdenv.mkDerivation rec {
-  pname = "xmake";
-  version = "2.9.1";
+}: let
+  mkDerivation =
+    if stdenv.isDarwin
+    then darwin.apple_sdk_11_0.stdenv.mkDerivation
+    else stdenv.mkDerivation;
+in
+  mkDerivation rec {
+    pname = "xmake";
+    version = "2.9.1";
 
-  src = fetchurl {
-    url = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-v${version}.tar.gz";
-    hash = "sha256-ox2++MMDrqEmgGi0sawa7BQqxBJMfLfZx+61fEFPjRU=";
-  };
+    src = fetchurl {
+      url = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-v${version}.tar.gz";
+      hash = "sha256-ox2++MMDrqEmgGi0sawa7BQqxBJMfLfZx+61fEFPjRU=";
+    };
 
-  # This patch is needed because, when building with Nix,
-  # coreutils' and findutils' versions of date and find are provided,
-  # which have slightly different behaviour to the macOS versions.
-  patches = [./macosx.patch];
+    # This patch is needed because, when building with Nix,
+    # coreutils' and findutils' versions of date and find are provided,
+    # which have slightly different behaviour to the macOS versions.
+    patches = [./macosx.patch];
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+    nativeBuildInputs = [
+      pkg-config
+    ];
 
-  buildInputs =
-    [
-      lua
-      readline
-      ncurses
-      lz4
-    ]
-    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreServices;
+    buildInputs =
+      [
+        lua
+        readline
+        ncurses
+        lz4
+      ]
+      ++ lib.optional stdenv.isDarwin darwin.apple_sdk_11_0.frameworks.CoreServices;
 
-  strictDeps = true;
+    strictDeps = true;
 
-  meta = with lib; {
-    description = "A cross-platform build utility based on Lua";
-    homepage = "https://xmake.io";
-    license = licenses.asl20;
-    platforms = lua.meta.platforms;
-  };
-}
+    meta = with lib; {
+      description = "A cross-platform build utility based on Lua";
+      homepage = "https://xmake.io";
+      license = licenses.asl20;
+      platforms = lua.meta.platforms;
+    };
+  }


### PR DESCRIPTION
tbox requires a minimum of Apple SDK 10.13 where on x86_64-darwin the current default is 10.12.