### PR TITLE
Disable tests when building verible

### DIFF
--- a/pkgs/verible.nix
+++ b/pkgs/verible.nix
@@ -25,11 +25,14 @@ verible.override (prev: {
         };
 
         fetchAttrs = {
-          sha256 = "sha256-bKASgc5KftCWtMvJkGA4nweBAtgdnyC9uXIJxPjKYS0=";
+          sha256 = "sha256-/kN1hyTcq+sARJkk7aOXVJVFhyTWdcREF4EwSmelVU4=";
         };
 
         patches = [];
 
         bazel = bazel_6;
+
+        # Disable tests (takes ~30m to run locally on a laptop)
+        bazelTestTargets = [];
       });
 })


### PR DESCRIPTION
When bumping flake.lock locally, after building verible the testing phase takes ~30m to run locally on a laptop. There's also not a huge amount of benefit in running the tests for us when we are statically pinning the version. Maybe in the future when building for our cache we can explicitly enable running the tests.