### PR TITLE
buildFHSEnvOverlay: remove `--fork --kill-child`

### DIFF
--- a/lib/buildFHSEnvOverlay.nix
+++ b/lib/buildFHSEnvOverlay.nix
@@ -192,7 +192,7 @@
 
   init = writeShellScript "${name}-init" initCmd;
   bin = writeShellScript "${name}-wrap" ''
-    ${util-linux}/bin/unshare --map-current-user --mount --keep-caps --fork --kill-child -- ${init} "$@"
+    ${util-linux}/bin/unshare --map-current-user --mount --keep-caps -- ${init} "$@"
   '';
 in
   runCommandLocal name {


### PR DESCRIPTION
We don't use PID namespaces so they're not needed.

Fix #62 