### PR TITLE
Re-introduce OpenSSL hack

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -86,6 +86,11 @@ in
         ++ extraPkgs;
     extraOutputsToInstall = ["dev"];
 
+    preExecHook = ''
+      ln -s ${pkgs.openssl.out}/etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+      ln -s /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
+    '';
+
     profile = ''
       # Workaround bazel bug: https://github.com/bazelbuild/bazel/issues/23217
       export TMPDIR=/tmp

--- a/lib/buildFHSEnvOverlay.nix
+++ b/lib/buildFHSEnvOverlay.nix
@@ -111,6 +111,11 @@
           /etc/profile | /etc/profile.d)
             continue
             ;;
+          # Needs special treatment to make /etc/ssl writable (needed in OT devShell for Bazel)
+          /etc/ssl)
+            ${coreutils}/bin/cp -rP $i $path
+            continue
+            ;;
           # Populated later
           /etc/ld.so*)
             continue


### PR DESCRIPTION
It's needed by Bazel for bitstream cache.