### PR TITLE
Update gcsfuse and init gcs-fuse-csi-driver-sidecar-mounter

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -27,6 +27,7 @@
 
   # IT packages
   gcsfuse = pkgs.callPackage ./gcsfuse {};
+  gcs-fuse-csi-driver-sidecar-mounter = pkgs.callPackage ./gcs-fuse-csi-driver-sidecar-mounter.nix {inherit gcsfuse;};
   container-hotplug = pkgs.callPackage ./container-hotplug {};
 
   surfer = pkgs.callPackage ./surfer/default.nix {};

--- a/pkgs/gcs-fuse-csi-driver-sidecar-mounter.nix
+++ b/pkgs/gcs-fuse-csi-driver-sidecar-mounter.nix
@@ -1,0 +1,62 @@
+# Copyright lowRISC Contributors.
+# Licensed under the MIT License, see LICENSE for details.
+# SPDX-License-Identifier: MIT
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  gcsfuse,
+  dockerTools,
+  runCommandLocal,
+  cacert,
+}: let
+  mounter = buildGoModule rec {
+    pname = "gcs-fuse-csi-driver-sidecar-mounter";
+    version = "1.8.0";
+
+    src = fetchFromGitHub {
+      owner = "googlecloudplatform";
+      repo = "gcs-fuse-csi-driver";
+      rev = "v${version}";
+      hash = "sha256-qJJLOek11ARxcrdB8M6UZh6PaJBV0tvVnL//ANn7YMc=";
+    };
+    vendorHash = null;
+
+    subPackages = ["cmd/sidecar_mounter"];
+
+    ldflags = ["-s" "-w" "-X main.version=${version}"];
+
+    postInstall = ''
+      mv $out/bin/sidecar_mounter $out/bin/gcs-fuse-csi-driver-sidecar-mounter
+    '';
+
+    dontCheck = true;
+
+    meta.mainProgram = pname;
+  };
+in
+  dockerTools.buildLayeredImage {
+    name = "gcs-fuse-csi-driver-sidecar-mounter";
+    tag = "latest";
+    contents = [
+      (runCommandLocal "root" {} ''
+        mkdir -p $out/etc/ssl/certs
+        ln -s ${lib.getExe gcsfuse} $out/
+        ln -s ${lib.getExe mounter} $out/
+        # Ensure SSL can still find certificates
+        ln -s ${cacert}/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs/ca-certificates.crt
+      '')
+    ];
+    config = {
+      Entrypoint = ["/gcs-fuse-csi-driver-sidecar-mounter"];
+    };
+  }
+  // {
+    meta = with lib; {
+      description = "Sidecar mounter for the Google Cloud Storage FUSE Container Storage Interface (CSI) Plugin";
+      homepage = "https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver";
+      changelog = "https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/releases/tag/v${version}";
+      license = licenses.asl20;
+      platforms = ["x86_64-linux"];
+    };
+  }

--- a/pkgs/gcsfuse/default.nix
+++ b/pkgs/gcsfuse/default.nix
@@ -2,23 +2,26 @@
 # Licensed under the MIT License, see LICENSE for details.
 # SPDX-License-Identifier: MIT
 {
+  stdenv,
+  go_1_23,
   gcsfuse,
   fetchFromGitHub,
 }:
 gcsfuse.override (prev: {
   buildGoModule = args:
-    prev.buildGoModule (args
+    (prev.buildGoModule.override {go = go_1_23;}) (args
       // rec {
-        version = "2.4.0";
+        # This is the upstream version, but we pin it.
+        version = "2.5.1";
 
         src = fetchFromGitHub {
           owner = "googlecloudplatform";
           repo = "gcsfuse";
           rev = "v${version}";
-          hash = "sha256-4susiXFe1aBcakxRkhmOe7dvcwsNfam4KKyFFzYXhcU=";
+          hash = "sha256-4UzRg6fNKBrTSoimJ9jURW9oPRhUOAUDMG3JaM7f100=";
         };
 
-        vendorHash = "sha256-uOr929RS8q7LB+WDiyxEIyScE/brmvPJKfnq28PfsDM=";
+        vendorHash = "sha256-QrpILFzgUQwmrvjCdtrlgq1zSW7f82qMHsifI39WaB0=";
 
         patches = [
           # https://github.com/GoogleCloudPlatform/gcsfuse/pull/2269
@@ -26,5 +29,12 @@ gcsfuse.override (prev: {
           # https://github.com/GoogleCloudPlatform/gcsfuse/pull/2285
           ./symlink-cache.patch
         ];
+
+        meta =
+          args.meta
+          // {
+            mainProgram = "gcsfuse";
+            broken = stdenv.hostPlatform.isDarwin;
+          };
       });
 })

--- a/pkgs/gcsfuse/dentry-cache.patch
+++ b/pkgs/gcsfuse/dentry-cache.patch
@@ -1,4 +1,4 @@
-From e1575385af3f980b88e3197bf524dc4c6ee15148 Mon Sep 17 00:00:00 2001
+From 6cd0bd89e5d79d5e323220553f1aa8761e7bd6a9 Mon Sep 17 00:00:00 2001
 From: Gary Guo <gary.guo@lowrisc.org>
 Date: Fri, 2 Aug 2024 11:32:48 +0100
 Subject: [PATCH 1/2] Set FUSE entry expiration time
@@ -33,10 +33,10 @@ Signed-off-by: Gary Guo <gary.guo@lowrisc.org>
  1 file changed, 6 insertions(+)
 
 diff --git a/internal/fs/fs.go b/internal/fs/fs.go
-index ba3e9f57cb..47de50323c 100644
+index befb0b417..d8bfa3c01 100644
 --- a/internal/fs/fs.go
 +++ b/internal/fs/fs.go
-@@ -1358,6 +1358,12 @@ func (fs *fileSystem) LookUpInode(
+@@ -1401,6 +1401,12 @@ func (fs *fileSystem) LookUpInode(
  		return err
  	}
  
@@ -50,7 +50,7 @@ index ba3e9f57cb..47de50323c 100644
  }
  
 
-From 85a9480bea86829af64cb6e7da31a0ae4cdceee7 Mon Sep 17 00:00:00 2001
+From 069b4a7d6c1b467f08a706db580ca514fc5a4a2a Mon Sep 17 00:00:00 2001
 From: Gary Guo <gary.guo@lowrisc.org>
 Date: Mon, 5 Aug 2024 13:50:10 +0100
 Subject: [PATCH 2/2] Enable negative dentry caching
@@ -64,10 +64,10 @@ Signed-off-by: Gary Guo <gary.guo@lowrisc.org>
  1 file changed, 10 insertions(+)
 
 diff --git a/internal/fs/fs.go b/internal/fs/fs.go
-index 47de50323c..f3c397db5b 100644
+index d8bfa3c01..bf7bdc233 100644
 --- a/internal/fs/fs.go
 +++ b/internal/fs/fs.go
-@@ -1344,6 +1344,16 @@ func (fs *fileSystem) LookUpInode(
+@@ -1387,6 +1387,16 @@ func (fs *fileSystem) LookUpInode(
  	// Find or create the child inode.
  	child, err := fs.lookUpOrCreateChildInode(ctx, parent, op.Name)
  	if err != nil {

--- a/pkgs/gcsfuse/symlink-cache.patch
+++ b/pkgs/gcsfuse/symlink-cache.patch
@@ -1,4 +1,4 @@
-From 22a47caa4826d68bb5d2b70c31261b50fb441a55 Mon Sep 17 00:00:00 2001
+From f6009299a4ba89453636424f90075a9c58f7d7d9 Mon Sep 17 00:00:00 2001
 From: Gary Guo <gary.guo@lowrisc.org>
 Date: Mon, 5 Aug 2024 12:44:11 +0100
 Subject: [PATCH 1/2] Fix size of symlinks
@@ -15,7 +15,7 @@ Signed-off-by: Gary Guo <gary.guo@lowrisc.org>
  1 file changed, 4 insertions(+)
 
 diff --git a/internal/fs/inode/symlink.go b/internal/fs/inode/symlink.go
-index 59db3079b7..145e431718 100644
+index eaa3a1667..5c66a826c 100644
 --- a/internal/fs/inode/symlink.go
 +++ b/internal/fs/inode/symlink.go
 @@ -84,6 +84,10 @@ func NewSymlinkInode(
@@ -30,7 +30,7 @@ index 59db3079b7..145e431718 100644
  		target: m.Metadata[SymlinkMetadataKey],
  	}
 
-From 8ef9d3d056f7b2c31469d6a119cfead366bda35c Mon Sep 17 00:00:00 2001
+From 5f01c89e9da7210c4023cd270f8cf43935c6a4ca Mon Sep 17 00:00:00 2001
 From: Gary Guo <gary.guo@lowrisc.org>
 Date: Sat, 3 Aug 2024 21:44:47 +0100
 Subject: [PATCH 2/2] Enable kernel symlink caching
@@ -48,13 +48,13 @@ Signed-off-by: Gary Guo <gary.guo@lowrisc.org>
  1 file changed, 3 insertions(+)
 
 diff --git a/cmd/mount.go b/cmd/mount.go
-index c8f19841c0..1fec7b9599 100644
+index 8096838ac..ec118db42 100644
 --- a/cmd/mount.go
 +++ b/cmd/mount.go
-@@ -174,6 +174,9 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config, mountConfig *confi
+@@ -165,6 +165,9 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig
  		// access two files under same directory parallely, then the lookups also
  		// happen parallely.
- 		EnableParallelDirOps: !(mountConfig.FileSystemConfig.DisableParallelDirops),
+ 		EnableParallelDirOps: !(newConfig.FileSystem.DisableParallelDirops),
 +		// Symlink target is not mutable (removing and re-creating would cause a different
 +		// inode to be created), so it's safe to enable symlink caching.
 +		EnableSymlinkCaching: true,


### PR DESCRIPTION
The gcs-fuse-csi-driver-sidecar-mounter package would generate a docker image that allow usage of performance-improved GCSFuse to be used in GKE.