### PR TITLE
buildFHSEnvOverlay: remove /usr/lib -> /usr/lib64 symlink

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -52,6 +52,7 @@ in
 
           # dvsim uses git for logging/tagging purposes
           git
+          gnumake
 
           # Bazel downloads Rust compilers which are not patchelfed and they need this.
           zlib


### PR DESCRIPTION
The symlink is not very compatible with Ubuntu.

Previously I had a workaround in #81 but it breaks NixOS instead, as in NixOS /etc/os-release links to another /etc path which is not yet mounted inside the namespace. Hopefully this time the solution can work for both Ubuntu and NixOS.