### PR TITLE
spike: bump to head of 'ibex-cosim'

### DIFF
--- a/pkgs/spike.nix
+++ b/pkgs/spike.nix
@@ -11,22 +11,15 @@
 # its Design Verification (DV) environment.
 spike.overrideAttrs (_: prev: {
   pname = "spike-ibex-cosim";
-  version = "0.5";
+  version = "0.5-dev";
 
   src = fetchFromGitHub {
     owner = "lowRISC";
     repo = "riscv-isa-sim";
-    rev = "ibex-cosim-v0.5";
-    sha256 = "sha256-LK/IXmRHrGxaMRudcUYmeZV5eXU8eH7ruIw7kliumdY=";
+    # Changes for cosimulation currently track the head of the 'ibex-cosim' branch.
+    rev = "39612f93837122a980395487f55b2d97d29d70c1";
+    sha256 = "sha256-GjOaaBggqU0eNXL2wsATNDaSEjVi6Kwaj8y2khx+4gA=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fesvr-fix-compilation-with-gcc-13.patch";
-      url = "https://github.com/riscv-software-src/riscv-isa-sim/commit/0a7bb5403d0290cea8b2356179d92e4c61ffd51d.patch";
-      hash = "sha256-JUMTbGawvLkoOWKkruzLzUFQytVR3wqTlGu/eegRFEE=";
-    })
-  ];
 
   configureFlags = (prev.configureFlags or []) ++ ["--enable-commitlog" "--enable-misaligned"];
 })


### PR DESCRIPTION
Since ibex#2259, ibex dv in ibex/master now requires spike from the head of the 'riscv-isa-sim/ibex-cosim' branch. A new release/tag may be cut in the future, but for now any updates should just track this branch.

This branch now contains a commit for the patch
"fesvr-fix-compilation-with-gcc-13.patch", so remove it from the override.

Related:
lowRISC/ibex#2183,lowRISC/riscv-isa-sim#25
lowRISC/ibex#2259