### PR TITLE
Don't touch when binding if file exists in buildFHSEnvOverlay

### DIFF
--- a/lib/buildFHSEnvOverlay.nix
+++ b/lib/buildFHSEnvOverlay.nix
@@ -79,7 +79,7 @@
       bind() {
         if [[ -d "$1" ]]; then
           ${coreutils}/bin/mkdir -p "$2"
-        else
+        elif ! [[ -e "$2" ]]; then
           ${coreutils}/bin/touch "$2"
         fi
         ${util-linux}/bin/mount --rbind "$1" "$2"


### PR DESCRIPTION
buildFHSEnvOverlay provides a helper function bind() which can be used to create mounts as part of its init script. This can bind to any arbitrary point in the filesystem, including over the top of existing files or directories.

If you bind to a read-only filesystem, the touch command will fail, and generate noise on stderr. This is irrelevant since the subsequent mount will then succeed regardless.

To avoid this, we can just avoid the touch command if the path we are binding to already exists.