### PR TITLE
Add numactl to opentitan devShell

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -80,6 +80,8 @@ in
           gcc-patched
           pkg-config-patched
 
+          numactl
+
           libxcrypt-legacy
           udev
           libftdi1


### PR DESCRIPTION
This is needed for simulation executables compiled by newer versions of vcs