### PR TITLE
Use evalFlake to hide flake inputs from downstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,59 +34,10 @@
         "type": "github"
       }
     },
-    "pyproject-build-systems": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749519371,
-        "narHash": "sha256-UJONN7mA2stweZCoRcry2aa1XTTBL0AfUOY84Lmqhos=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "7c06967eca687f3482624250428cc12f43c92523",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1750499893,
-        "narHash": "sha256-ThKBd8XSvITAh2JqU7enOp8AfKeQgf9u7zYC41cnBE4=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "e824458bd917b44bf4c38795dea2650336b2f55d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -101,29 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749778965,
-        "narHash": "sha256-MDq5YPXq3VO7aGrIIz9IMexJcdRiLCcDK4Bk3Kev7Sw=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "22ddf88e3a06551b769f0a585601d89180c69a38",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -7,24 +7,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
-
-    pyproject-nix = {
-      url = "github:pyproject-nix/pyproject.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    uv2nix = {
-      url = "github:pyproject-nix/uv2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.pyproject-nix.follows = "pyproject-nix";
-    };
-
-    pyproject-build-systems = {
-      url = "github:pyproject-nix/build-system-pkgs";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.pyproject-nix.follows = "pyproject-nix";
-      inputs.uv2nix.follows = "uv2nix";
-    };
   };
 
   nixConfig = {
@@ -37,14 +19,25 @@
     nixpkgs,
     flake-utils,
     ...
-  } @ inputs: let
+  } @ publicInputs: let
+    evalFlake = import ./lib/evalFlake.nix;
+
+    inputs =
+      (evalFlake {
+        src = ./private;
+        inputOverride = {
+          inherit nixpkgs;
+        };
+      }).inputs
+      // publicInputs;
+
     no_system_outputs = {
       lib = {
         poetryOverrides = import ./lib/poetryOverrides.nix;
         pyprojectOverrides = import ./lib/pyprojectOverrides.nix;
         doc = import ./lib/doc.nix;
         buildFHSEnvOverlay = import ./lib/buildFHSEnvOverlay.nix;
-        evalFlake = import ./lib/evalFlake.nix;
+        inherit evalFlake;
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
         pyprojectOverrides = import ./lib/pyprojectOverrides.nix;
         doc = import ./lib/doc.nix;
         buildFHSEnvOverlay = import ./lib/buildFHSEnvOverlay.nix;
+        evalFlake = import ./lib/evalFlake.nix;
       };
     };
 

--- a/lib/evalFlake.nix
+++ b/lib/evalFlake.nix
@@ -1,0 +1,174 @@
+# Copyright (c) 2020-2021 Eelco Dolstra and the flake-compat contributors.
+# Copyright lowRISC Contributors.
+#
+# SPDX-License-Identifier: MIT
+#
+# This is modified from edolstra's flake-compat to perform input override
+{
+  src,
+  inputOverride ? {},
+}: let
+  lockFilePath = src + "/flake.lock";
+  lockFile = builtins.fromJSON (builtins.readFile lockFilePath);
+
+  rootSrc = let
+    # Try to clean the source tree by using fetchGit, if this source
+    # tree is a valid git repository.
+    tryFetchGit = src:
+      if isGit && !isShallow
+      then let
+        res = builtins.fetchGit src;
+      in
+        if res.rev == "0000000000000000000000000000000000000000"
+        then removeAttrs res ["rev" "shortRev"]
+        else res
+      else {
+        outPath =
+          # Massage `src` into a store path.
+          if builtins.isPath src
+          then
+            if dirOf (toString src) == builtins.storeDir
+            then
+              # If it's already a store path, don't copy it again.
+              builtins.storePath src
+            else "${src}"
+          else src;
+      };
+    # NB git worktrees have a file for .git, so we don't check the type of .git
+    isGit = builtins.pathExists (src + "/.git");
+    isShallow = builtins.pathExists (src + "/.git/shallow");
+  in
+    {
+      lastModified = 0;
+      lastModifiedDate = formatSecondsSinceEpoch 0;
+    }
+    // (
+      if src ? outPath
+      then src
+      else tryFetchGit src
+    );
+
+  # Format number of seconds in the Unix epoch as %Y%m%d%H%M%S.
+  formatSecondsSinceEpoch = t: let
+    rem = x: y: x - x / y * y;
+    days = t / 86400;
+    secondsInDay = rem t 86400;
+    hours = secondsInDay / 3600;
+    minutes = (rem secondsInDay 3600) / 60;
+    seconds = rem t 60;
+
+    # Courtesy of https://stackoverflow.com/a/32158604.
+    z = days + 719468;
+    era =
+      (
+        if z >= 0
+        then z
+        else z - 146096
+      )
+      / 146097;
+    doe = z - era * 146097;
+    yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    y = yoe + era * 400;
+    doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    mp = (5 * doy + 2) / 153;
+    d = doy - (153 * mp + 2) / 5 + 1;
+    m =
+      mp
+      + (
+        if mp < 10
+        then 3
+        else -9
+      );
+    y' =
+      y
+      + (
+        if m <= 2
+        then 1
+        else 0
+      );
+
+    pad = s:
+      if builtins.stringLength s < 2
+      then "0" + s
+      else s;
+  in "${toString y'}${pad (toString m)}${pad (toString d)}${pad (toString hours)}${pad (toString minutes)}${pad (toString seconds)}";
+
+  allNodes =
+    builtins.mapAttrs
+    (
+      key: node: let
+        sourceInfo =
+          if key == lockFile.root
+          then rootSrc
+          else fetchTree (node.info or {} // removeAttrs node.locked ["dir"]);
+
+        subdir =
+          if key == lockFile.root
+          then ""
+          else node.locked.dir or "";
+
+        outPath =
+          sourceInfo
+          + ((
+              if subdir == ""
+              then ""
+              else "/"
+            )
+            + subdir);
+
+        flake = import (outPath + "/flake.nix");
+
+        inputs =
+          builtins.mapAttrs
+          (inputName: inputSpec:
+            if inputOverride ? ${inputName}
+            then inputOverride.${inputName}
+            else allNodes.${resolveInput inputSpec})
+          (node.inputs or {});
+
+        # Resolve a input spec into a node name. An input spec is
+        # either a node name, or a 'follows' path from the root
+        # node.
+        resolveInput = inputSpec:
+          if builtins.isList inputSpec
+          then getInputByPath lockFile.root inputSpec
+          else inputSpec;
+
+        # Follow an input path (e.g. ["dwarffs" "nixpkgs"]) from the
+        # root node, returning the final node.
+        getInputByPath = nodeName: path:
+          if path == []
+          then nodeName
+          else
+            getInputByPath
+            # Since this could be a 'follows' input, call resolveInput.
+            (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
+            (builtins.tail path);
+
+        outputs = flake.outputs (inputs // {self = result;});
+
+        result =
+          outputs
+          # We add the sourceInfo attribute for its metadata, as they are
+          # relevant metadata for the flake. However, the outPath of the
+          # sourceInfo does not necessarily match the outPath of the flake,
+          # as the flake may be in a subdirectory of a source.
+          # This is shadowed in the next //
+          // sourceInfo
+          // {
+            # This shadows the sourceInfo.outPath
+            inherit outPath;
+
+            inherit inputs;
+            inherit outputs;
+            inherit sourceInfo;
+            _type = "flake";
+          };
+      in
+        if node.flake or true
+        then assert builtins.isFunction flake.outputs; result
+        else sourceInfo
+    )
+    lockFile.nodes;
+in
+  allNodes.${lockFile.root}

--- a/private/flake.lock
+++ b/private/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750400657,
+        "narHash": "sha256-3vkjFnxCOP6vm5Pm13wC/Zy6/VYgei/I/2DWgW4RFeA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b2485d56967598da068b5a6946dadda8bfcbcd37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749519371,
+        "narHash": "sha256-UJONN7mA2stweZCoRcry2aa1XTTBL0AfUOY84Lmqhos=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7c06967eca687f3482624250428cc12f43c92523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750499893,
+        "narHash": "sha256-ThKBd8XSvITAh2JqU7enOp8AfKeQgf9u7zYC41cnBE4=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e824458bd917b44bf4c38795dea2650336b2f55d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749778965,
+        "narHash": "sha256-MDq5YPXq3VO7aGrIIz9IMexJcdRiLCcDK4Bk3Kev7Sw=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "22ddf88e3a06551b769f0a585601d89180c69a38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/private/flake.nix
+++ b/private/flake.nix
@@ -1,0 +1,28 @@
+# Copyright lowRISC Contributors.
+#
+# SPDX-License-Identifier: MIT
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+    };
+  };
+
+  outputs = _: {};
+}


### PR DESCRIPTION
This would allow us to add inputs without filling downstream users' flake.lock.