### PR TITLE
ci: drop x86_64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             # We only support MacOS with best-effort basis. They take much longer to build so shouldn't block PR.
             SYSTEMS=(x86_64-linux)
           else
-            SYSTEMS=(x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin)
+            SYSTEMS=(x86_64-linux aarch64-linux aarch64-darwin)
           fi
 
           for SYSTEM in "${SYSTEMS[@]}"; do
@@ -91,7 +91,7 @@ jobs:
         include: ${{fromJSON(needs.check.outputs.matrix)}}
       # Disable fail-fast for non-PR builds to ensure all outputs have a chance to be built.
       fail-fast: ${{ github.event_name == 'pull_request' }}
-    runs-on: ${{ matrix.system == 'x86_64-darwin' && 'macos-13' || (matrix.system == 'aarch64-darwin' && 'macos-14' || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm' || 'nixos')) }}
+    runs-on: ${{ matrix.system == 'aarch64-darwin' && 'macos-14' || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm' || 'nixos') }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Cache
         if: github.event_name != 'pull_request'
         run: |
-          nix profile install github:NixOS/nixpkgs/nixos-24.11#attic-client
+          nix profile install nixpkgs#attic-client
           attic login --set-default lowrisc https://nix-cache.lowrisc.org/ ${{ secrets.NIX_CACHE_TOKEN }}
 
       - name: Build

--- a/pkgs/cheriot-sim.nix
+++ b/pkgs/cheriot-sim.nix
@@ -62,7 +62,5 @@ in
       homepage = "https://github.com/microsoft/cheriot-sail";
       license = lib.licenses.bsd2;
       mainProgram = "cheriot_sim";
-      # This package is broken on x64 MacOS with SMT solver being killed error.
-      broken = stdenv.system == "x86_64-darwin";
     };
   }

--- a/pkgs/nebula.nix
+++ b/pkgs/nebula.nix
@@ -16,11 +16,11 @@ nebula.override (prev: {
         src = fetchFromGitHub {
           owner = "slackhq";
           repo = "nebula";
-          rev = "8536c5764565fcb0381c37772811b92c001d1b89";
-          hash = "sha256-o6/4R5qwLl00CWHlP/bdju/7k5PhlXyazB+cYIePVY0=";
+          rev = "7da79685fff9b34c30b3c6786ebf4b97b091daa1";
+          hash = "sha256-jk9aVkQe4klqeWVMop/HLxqr0flgEKiOSTBndHRAIG0=";
         };
 
-        vendorHash = "sha256-X4hnVilPFDaF6QUbjNZqvbk9Jmd+iTL2Ij7Tv5SXrbg=";
+        vendorHash = "sha256-dtjxzRRQagkXFLQGwE//apon7kFuxYJXT9KLhJS7m5k=";
 
         ldflags = ["-X main.Build=${version}"];
       });


### PR DESCRIPTION
x64 MacOS support causes troubles in the past. Given the MacOS 13 runner will be deprecated soon (September) and Apple announcing an end to new x86 devices, just drop its support.

I updated dev version of nebula to test that the pipeline still works.