### PR TITLE
[caliptra] XXD added as package

### DIFF
--- a/dev/caliptra.nix
+++ b/dev/caliptra.nix
@@ -18,6 +18,7 @@ in
     name = "caliptra";
 
     nativeBuildInputs = with pkgs; [
+      xxd
       verilator_caliptra
       riscv64-gcc_caliptra
       hjson


### PR DESCRIPTION
This is needed for Caliptra RTL top-level simulation.