### PR TITLE
buildFHSEnvOverlay, opentitan: fix /etc/ssl handling

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -139,11 +139,36 @@ in
         ++ extraPkgs;
     extraOutputsToInstall = ["dev"];
 
-    # Some Bazel downloaded binary ship their own openssl, which try to find files in this location,
-    # So symlink them. They may alraedy exist (e.g. when already in an OT FHS env), so ignore if this fails.
+    # Bazel downloads pre-built host tools (Rust toolchain, curl, etc.) that were
+    # compiled on a standard FHS Linux system with OPENSSLDIR=/etc/ssl baked in at
+    # compile time. These unpatched binaries look for openssl.cnf and the CA trust
+    # bundle at /etc/ssl regardless of any environment variables, since Bazel's
+    # sandbox strips most env vars (including SSL_CERT_FILE) before running actions.
     preExecHook = ''
-      ln -s ${pkgs.openssl.out}/etc/ssl/openssl.cnf /etc/ssl/openssl.cnf 2>/dev/null
-      ln -s /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem 2>/dev/null
+      # Only populate openssl.cnf if it is absent or a dangling symlink, indicated
+      # by [ -e ] returning false (it follows symlinks, so a dangling symlink to a
+      # garbage-collected Nix store path on NixOS will also fail this test).
+      # A valid host file is preserved to retain any system-specific crypto policy:
+      # Fedora/RHEL include /etc/crypto-policies/back-ends/opensslcnf.config via
+      # an .include directive, and Debian/Ubuntu configure SECLEVEL and MinProtocol.
+      if ! [ -e /etc/ssl/openssl.cnf ]; then
+        ln -sf ${pkgs.openssl.out}/etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
+      fi
+
+      # Populate /etc/ssl/cert.pem if absent or dangling, trying CA bundle
+      # locations used by common distributions in order of preference.
+      if ! [ -e /etc/ssl/cert.pem ]; then
+        for ca_bundle in \
+          /etc/ssl/certs/ca-certificates.crt \
+          /etc/pki/tls/certs/ca-bundle.crt \
+          /etc/ssl/certs/ca-bundle.crt \
+          /etc/ssl/ca-bundle.pem; do
+          if [ -f "$ca_bundle" ]; then
+            ln -sf "$ca_bundle" /etc/ssl/cert.pem
+            break
+          fi
+        done
+      fi
     '';
 
     profile = ''

--- a/lib/buildFHSEnvOverlay.nix
+++ b/lib/buildFHSEnvOverlay.nix
@@ -127,9 +127,17 @@
           /etc/profile | /etc/profile.d)
             continue
             ;;
-          # Needs special treatment to make /etc/ssl writable (needed in OT devShell for Bazel)
+          # /etc/ssl needs to be writable so preExecHook and similar can create new
+          # files within it (e.g. symlinking CA certs or openssl.cnf). A writable
+          # overlay keeps all host content visible without copying, which avoids
+          # permission errors on restricted subdirectories such as /etc/ssl/private
+          # that exist (mode 700, root-owned) on most Linux distributions.
           /etc/ssl)
-            ${coreutils}/bin/cp -rP $i $path
+            ${coreutils}/bin/mkdir -p /etc/ssl
+            if [[ -d "$i" ]]; then
+              ${coreutils}/bin/mkdir -p /etc/.ssl-overlay/upper /etc/.ssl-overlay/work
+              ${util-linux}/bin/mount none -t overlay -o lowerdir="$i",upperdir=/etc/.ssl-overlay/upper,workdir=/etc/.ssl-overlay/work /etc/ssl
+            fi
             continue
             ;;
           # Populated later


### PR DESCRIPTION
Replace the recursive copy of the host's /etc/ssl with a writable overlayfs mount. The previous cp -rP would produce a permission error on /etc/ssl/private (mode 700, root-owned on most Linux distributions) when entering the devShell on non-NixOS systems. All host content remains visible through the overlay lowerdir without any copying.

The overlay upper and work directories are placed under /etc/.ssl-overlay/ rather than /tmp/ to avoid prematurely creating /tmp in the new root. Creating /tmp before the host bind-mount loop would cause that loop to skip mounting the host's /tmp, hiding X11 sockets, SSH agent sockets, and other runtime state.

In opentitan.nix, the preExecHook is reworked:

- openssl.cnf is now only created when absent or a dangling symlink. The [ -e ] test follows symlinks and returns false for dangling symlinks, so stale Nix store references on NixOS (after garbage collection) are replaced while a valid host file is preserved. This is important on Fedora/RHEL where openssl.cnf includes /etc/crypto-policies/back-ends/opensslcnf.config, and on Debian/Ubuntu where it sets SECLEVEL and MinProtocol.

- cert.pem is populated by searching common CA bundle locations across distributions rather than hardcoding the Debian/Ubuntu ca-certificates.crt filename. Fedora/RHEL, openSUSE, and other distributions are now covered.

- Both use ln -sf so that dangling symlinks are replaced atomically via the overlay's whiteout mechanism rather than silently failing.