### PR TITLE
ci: Migrate to token-request flow for attic push access to public nix cache

### DIFF
--- a/.github/actions/lowrisc_ci_app_get_token/action.yml
+++ b/.github/actions/lowrisc_ci_app_get_token/action.yml
@@ -1,0 +1,41 @@
+# Copyright lowRISC contributors.
+#
+# SPDX-License-Identifier: MIT
+
+# NOTE.
+# Requires id-token: write in the calling job to get the JWT
+
+name: Get lowrisc-ci app access token
+description: Obtain a lowrisc-ci GitHub App installation access token from the lowRISC CA
+
+inputs:
+  audience:
+    description: intended audience for the requested JWT
+    type: string
+    default: "https://ca.lowrisc.org"
+  ca_api_endpoint:
+    description: lowRISC CA endpoint from which to try and obtain a token.
+    type: string
+    default: "https://ca.lowrisc.org/api/github/repos/${{ github.repository }}/token"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get and exchange tokens
+      id: get_token
+      shell: bash
+      run: |
+        # First, manually request a JSON Web Token (JWT) from GitHub's OIDC provider for the job
+        # - Set our CA as the intended audience
+        ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ inputs.audience }}" | jq -r .value)
+        echo "::add-mask::$ID_TOKEN"
+        # Now use the JWT token to request the lowRISC CA to provide a lowrisc-ci app installation access token suitable for our action
+        ACCESS_TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $ID_TOKEN" ${{ inputs.ca_api_endpoint }})
+        echo "::add-mask::$ACCESS_TOKEN"
+        echo "token=$ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
+
+outputs:
+  token:
+    description: "Token"
+    value: ${{ steps.get_token.outputs.token }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
   build:
     needs: check
     name: Build
+    permissions:
+      id-token: write
     # Matrix can't be empty, so skip the job entirely if nothing needs to be rebuilt.
     if: fromJSON(needs.check.outputs.matrix)[0] != null
     strategy:
@@ -108,11 +110,16 @@ jobs:
             substituters = https://nix-cache.lowrisc.org/public/ https://cache.nixos.org/
             trusted-public-keys = nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
+      - name: Get a short-lived lowrisc-ci app token for pushing to the attic nix cache
+        id: get-token
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/lowrisc_ci_app_get_token
+
       - name: Setup Cache
         if: github.event_name != 'pull_request'
         run: |
           nix profile install nixpkgs#attic-client
-          attic login --set-default lowrisc https://nix-cache.lowrisc.org/ ${{ secrets.NIX_CACHE_TOKEN }}
+          attic login --set-default lowrisc https://nix-cache.lowrisc.org/ ${{ steps.get-token.outputs.token }}
 
       - name: Build
         run: |


### PR DESCRIPTION
The current CI is using a hardcoded token in the repo secrets. 
The lowrisc CA now exists to facilitate requests for short-lived tokens.