### PR TITLE
ci: Fix get-token to access correct api endpoint for nix caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,12 @@ jobs:
             substituters = https://nix-cache.lowrisc.org/public/ https://cache.nixos.org/
             trusted-public-keys = nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
-      - name: Get a short-lived lowrisc-ci app token for pushing to the attic nix cache
+      - name: Get a short-lived lowrisc-ci app token for pushing to the attic public nix cache
         id: get-token
         if: github.event_name != 'pull_request'
         uses: ./.github/actions/lowrisc_ci_app_get_token
+        with:
+          ca_api_endpoint: "https://ca.lowrisc.org/api/nix-caches/public/token"
 
       - name: Setup Cache
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
#174 used the wrong CA api-endpoint, and hence was unauthorized, e.g. https://github.com/lowRISC/lowrisc-nix/actions/runs/24244709991/job/70787988551f
Fix to use the correct one: `/api/nix-caches/<cache>/token`