### PR TITLE
chore: migrate to NixOS 26.05 with fixes

### DIFF
--- a/dev/opentitan.nix
+++ b/dev/opentitan.nix
@@ -37,7 +37,11 @@
   # Bazel filters out all environment including PKG_CONFIG_PATH. Append this inside wrapper.
   pkg-config-patched = pkg-config.override {
     extraBuildCommands = ''
+      # nixpkgs installs utils.bash read-only (install -m444), so make it
+      # writable to append, then restore the original mode.
+      chmod +w $out/nix-support/utils.bash
       echo "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/lib/pkgconfig" >> $out/nix-support/utils.bash
+      chmod 444 $out/nix-support/utils.bash
     '';
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "lowRISC CIC's Nix Packages and Environments";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
 
     # We also have some additional dependencies in private/flake.nix.

--- a/pkgs/cheriot-sim.nix
+++ b/pkgs/cheriot-sim.nix
@@ -33,6 +33,13 @@ in
       gmp
     ];
 
+    # GCC 15 (NixOS 26.05) defaults to C23, where an empty parameter list `()`
+    # means `(void)`. Sail 0.20.1's runtime declares `platform_barrier()` with no
+    # args, but the generated model calls it with the barrier_kind argument, so
+    # the build fails with "too many arguments". Compile as C17 to restore the
+    # pre-C23 unspecified-arguments semantics.
+    env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
     nativeBuildInputs = [
       ocaml
       pkg-config

--- a/pkgs/peakrdl.nix
+++ b/pkgs/peakrdl.nix
@@ -79,12 +79,14 @@
           ]
           ++ additionalInputs;
         format = "pyproject";
-        meta = {
-          inherit description mainProgram;
-          homepage = "https://github.com/SystemRDL/${pname}";
-          license = lib.licenses.gpl3;
-          platforms = lib.platforms.all;
-        };
+        meta =
+          {
+            inherit description;
+            homepage = "https://github.com/SystemRDL/${pname}";
+            license = lib.licenses.gpl3;
+            platforms = lib.platforms.all;
+          }
+          // lib.optionalAttrs (mainProgram != null) {inherit mainProgram;};
       }
       // (removeAttrs args [
         "rev"

--- a/pkgs/python_ot/default.nix
+++ b/pkgs/python_ot/default.nix
@@ -4,13 +4,14 @@
 {
   inputs,
   pkgs,
-  python310,
+  python312,
+  python311,
   lib,
   ...
 }: let
   pythonSets = {
-    "main" = python310;
-    "earlgrey_1.0.0" = python310;
+    "main" = python312;
+    "earlgrey_1.0.0" = python311;
   };
 
   mkEnv = workspaceRoot: python: let

--- a/pkgs/python_ot/main/pyproject.toml
+++ b/pkgs/python_ot/main/pyproject.toml
@@ -6,7 +6,7 @@
 name = "opentitan"
 version = "0.0.0"
 description = "Open-source hardware root-of-trust"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.12, <3.14"
 
 dependencies = [
   # Keep sorted

--- a/pkgs/riscv64-gcc_caliptra/default.nix
+++ b/pkgs/riscv64-gcc_caliptra/default.nix
@@ -31,6 +31,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # GCC 15 defaults to -std=gnu23, where empty-parens declarations like
+  # `extern int tputs ();` become zero-argument prototypes. The bundled GDB's
+  # readline still calls these with arguments, so force the pre-C23 dialect for
+  # host C compilation. Only affects C; the gcc C++ sources use CXXFLAGS.
+  CFLAGS = "-O2 -g -std=gnu17";
+
   hardeningDisable = ["format"];
   buildInputs = with pkgs; [
     gmp

--- a/pkgs/sv-lang.nix
+++ b/pkgs/sv-lang.nix
@@ -1,32 +1,38 @@
 # Copyright lowRISC Contributors.
 # SPDX-License-Identifier: MIT
-{pkgs}:
-pkgs.sv-lang.overrideAttrs (prev: rec {
-  version = "7.0";
-  src = pkgs.fetchFromGitHub {
-    owner = "MikePopoloski";
-    repo = "slang";
-    rev = "v${version}";
-    sha256 = "sha256-msSc6jw2xbEZfOwtqwFEDIKcwf5SDKp+j15lVbNO98g=";
+{pkgs}: let
+  # slang 7.0's tools fail to compile under GCC 15's stricter template-body
+  # checking, so build with GCC 14 as it did before the NixOS 26.05 bump.
+  sv-lang = pkgs.sv-lang.override {
+    stdenv = pkgs.gcc14Stdenv;
   };
+in
+  sv-lang.overrideAttrs (prev: rec {
+    version = "7.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "MikePopoloski";
+      repo = "slang";
+      rev = "v${version}";
+      sha256 = "sha256-msSc6jw2xbEZfOwtqwFEDIKcwf5SDKp+j15lVbNO98g=";
+    };
 
-  # Upstream has a patch for mimalloc, which we aren't using.
-  postPatch = "";
+    # Upstream has a patch for mimalloc, which we aren't using.
+    postPatch = "";
 
-  # Detrimental when using sv-lang as library.
-  cmakeFlags =
-    prev.cmakeFlags
-    ++ [
-      "-DSLANG_USE_MIMALLOC=OFF"
-    ];
+    # Detrimental when using sv-lang as library.
+    cmakeFlags =
+      prev.cmakeFlags
+      ++ [
+        "-DSLANG_USE_MIMALLOC=OFF"
+      ];
 
-  # Needed by dependent project.
-  propagatedBuildInputs =
-    (prev.propagatedBuildInputs or [])
-    ++ [
-      pkgs.fmt
-    ];
+    # Needed by dependent project.
+    propagatedBuildInputs =
+      (prev.propagatedBuildInputs or [])
+      ++ [
+        pkgs.fmt
+      ];
 
-  # Time out specific to sv-lang 7, see https://github.com/nixos/nixpkgs/issues/451986.
-  doCheck = false;
-})
+    # Time out specific to sv-lang 7, see https://github.com/nixos/nixpkgs/issues/451986.
+    doCheck = false;
+  })

--- a/pkgs/verible_ot.nix
+++ b/pkgs/verible_ot.nix
@@ -10,11 +10,17 @@
   stdenv,
 }:
 verible.override (prev: {
-  buildBazelPackage = args:
+  buildBazelPackage = args: let
+    GIT_DATE = "2024-03-13";
+    GIT_VERSION = "v0.0-3622-g07b310a3";
+  in
     prev.buildBazelPackage (args
-      // rec {
-        GIT_DATE = "2024-03-13";
-        GIT_VERSION = "v0.0-3622-g07b310a3";
+      // {
+        env =
+          (args.env or {})
+          // {
+            inherit GIT_DATE GIT_VERSION;
+          };
 
         version = builtins.concatStringsSep "." (lib.take 3 (lib.drop 1 (builtins.splitVersion GIT_VERSION)));
 
@@ -28,8 +34,8 @@ verible.override (prev: {
         fetchAttrs = {
           hash =
             {
-              aarch64-linux = "sha256-igGOwq+RKHlvGsR01JlQlasccbeOe3MIMnpGKQHjwk0=";
-              x86_64-linux = "sha256-JaAb80YGRqB2sgZiwmqWvCNETachdxV34cwFUuV/2gg=";
+              aarch64-linux = "sha256-8FKnbiyf3psntL6ioq3cVpyBKwvNMC2VqmLqWuDafVk=";
+              x86_64-linux = "sha256-oUEiqYE6cE6RToXtKCb6IKnI8HVNXaFHxdRL/1iDwhU=";
               aarch64-darwin = "sha256-FoTsIEF+HAFRrUmiuiPjxZnm9hirq25qgmP5JhSXiEA=";
             }
       .${


### PR DESCRIPTION
Python 3.10 is not available in 26.05, so bump to 3.12 for the OT devshell. Also had to resolve a couple of other issues in the migration process.