### PR TITLE
fix(eda): add missing csh

### DIFF
--- a/lib/edaFhsPackages.nix
+++ b/lib/edaFhsPackages.nix
@@ -26,6 +26,16 @@
       (pkgs.callPackage ../pkgs/ncurses6-fhs.nix {})
     ];
   };
+
+  # Some vendor tool scripts have a `#!/bin/csh` shebang. nixpkgs' tcsh does
+  # not itself provide a `csh` name, so add one.
+  tcsh-fhs = pkgs.symlinkJoin {
+    name = "tcsh-fhs";
+    paths = [pkgs.tcsh];
+    postBuild = ''
+      ln -s ${pkgs.tcsh}/bin/tcsh $out/bin/csh
+    '';
+  };
 in
   with pkgs;
     [
@@ -36,6 +46,7 @@ in
       bash
       coreutils
       ksh
+      tcsh-fhs
       perl
       bc
       time


### PR DESCRIPTION
Some vendors rely on `csh` being available for wrapper/shim scripts.

With this I'm able to do:
```
> cd opentitan
> nix develop .
> dvsim -pi=1 --tool=xcelium hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson -i rom_ctrl_smoke --fi=0
```

With success:

```
[I 260721 14:18:22 report:477] [results]: [rom_ctrl_64kb]
## ROM_CTRL/64KB Simulation Results
### Tuesday July 21 2026 13:16:50 UTC
### GitHub Revision: [`bcf1f901e8`](https://github.com/lowrisc/opentitan/tree/bcf1f901e8a081155d3716aa182fd8ee8fca422f)
### Branch: fix-devshell
### [Testplan](https://opentitan.org/book/hw/ip/rom_ctrl_64kB/data/rom_ctrl_testplan.html)
### Simulator: XCELIUM

### Test Results

|  Stage  |         Name         | Tests          |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:--------------------:|:---------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |        smoke         | rom_ctrl_smoke |      14.000s      |    1246.557us    |     1     |    1    |  100.00 %   |
|   V1    |                      | **TOTAL**      |                   |                  |     1     |    1    |  100.00 %   |
|   V2S   | sec_cm_mem_scramble  | rom_ctrl_smoke |      14.000s      |    1246.557us    |     1     |    1    |  100.00 %   |
|   V2S   |  sec_cm_mem_digest   | rom_ctrl_smoke |      14.000s      |    1246.557us    |     1     |    1    |  100.00 %   |
|   V2S   | sec_cm_intersig_mubi | rom_ctrl_smoke |      14.000s      |    1246.557us    |     1     |    1    |  100.00 %   |
|   V2S   |                      | **TOTAL**      |                   |                  |     1     |    1    |  100.00 %   |
|         |                      | **TOTAL**      |                   |                  |     1     |    1    |  100.00 %   |

## Coverage Results
### [Coverage Dashboard](opentitan/scratch/fix-devshell/rom_ctrl_64kB-sim-xcelium/cov_report/index.html)


          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]
00:01:17  [    build    ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%
00:01:31  [     run     ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%
```